### PR TITLE
Removing 2019 and updating label.

### DIFF
--- a/js/components/nav.js
+++ b/js/components/nav.js
@@ -16,8 +16,8 @@ document.getElementById('nav').innerHTML=`
                                     <li id="schedule"><a href="program.html">Schedule</a></li>
                                     <li>
                                         <select onchange='location = this.value;'>
-                                            <option value='#'>Current (2020)</option>
-                                            <option value='2019/index.html'>2019</option>
+                                            <option value='#'>2020</option>
+                                            <!--<option value='2019/index.html'>2019</option>-->
                                         </select>
                                     </li>
                                 </ul>


### PR DESCRIPTION
Leaving the option dropdown for now even though there is only one option, but will be easy to add 2021 later.